### PR TITLE
Pair encoding

### DIFF
--- a/src/urm/core.clj
+++ b/src/urm/core.clj
@@ -45,7 +45,7 @@
                 from-value (get-in state [:registers from] 0)
                 to-value (get-in state [:registers to] 0)]
             (-> state
-                (assoc-in [:registers to] (code-pair from-value to-value))
+                (assoc-in [:registers to] (code-pair [from-value to-value]))
                 (assoc-in [:registers from] 0)
                 (assoc :position exit)))
     :pop  (let [[from to halt exit] args
@@ -96,7 +96,7 @@
             (+ 1 so-far))
      so-far)))
 
-(defn code-pair [x y]
+(defn code-pair [[x y]]
   (* (math/expt 2 x)
      (+ (* 2 y) 1)))
 
@@ -106,8 +106,8 @@
              2)]
     [x y]))
 
-(defn code-pair* [x y]
-  (dec (code-pair x y)))
+(defn code-pair* [pair]
+  (dec (code-pair pair)))
 
 (defn uncode-pair* [n]
   (decode-pair (+ n 1)))
@@ -115,7 +115,7 @@
 (defn code-list [[h & t :as number-list]]
   (if (empty? number-list)
     0
-    (code-pair h (code-list t))))
+    (code-pair [h (code-list t)])))
 
 (defn decode-list [code]
   (if (== code 0)
@@ -126,9 +126,9 @@
 
 (defn code-instruction [[instruction register jump-to branch-on-zero]]
   (case instruction
-    :inc (code-pair (* 2 register) jump-to)
-    :deb (code-pair (+ (* 2 register) 1)
-               (code-pair* jump-to branch-on-zero))
+    :inc (code-pair [(* 2 register) jump-to])
+    :deb (code-pair [(+ (* 2 register) 1)
+                     (code-pair* [jump-to branch-on-zero])])
     :end 0))
 
 (defn decode-instruction [code]

--- a/test/urm/core_test.clj
+++ b/test/urm/core_test.clj
@@ -12,8 +12,8 @@
 (expect 3
         ((urm->fn add) 1 2))
 
-(expect (code-pair 0 13)
-        (code-pair* 2 3))
+(expect (code-pair [0 13])
+        (code-pair* [2 3]))
 
 (expect 8
         (code-list [3]))
@@ -38,6 +38,9 @@
 
 (expect [0 13]
         (decode-pair 27))
+
+(expect 28
+        (code-pair (decode-pair (code-pair [2 3]))))
 
 (expect [2 3]
         (uncode-pair* 27))
@@ -85,10 +88,10 @@
          2 3
          9 0}
 
-        (:registers (run {:program [(pop 1 2 1 1)
-                                    (end)]
-                          :position 0
-                          :registers {1 (code-pair 3 11)
+        (:registers (run {:program   [(pop 1 2 1 1)
+                                      (end)]
+                          :position  0
+                          :registers {1 (code-pair [3 11])
                                       2 0
                                       9 0}})))
 

--- a/test/urm/core_test.clj
+++ b/test/urm/core_test.clj
@@ -8,30 +8,32 @@
                    (end)]
                   []))
 
-
 (expect 3
         ((urm->fn add) 1 2))
 
-(expect (code-pair [0 13])
-        (code-pair* [2 3]))
+(expect (encode-pair [0 13])
+        (encode-pair* [2 3]))
 
 (expect 8
-        (code-list [3]))
+        (encode-list [3]))
 
 (expect 34
-        (code-list [1 3]))
+        (encode-list [1 3]))
 
 (expect 276
-        (code-list [2 1 3]))
+        (encode-list [2 1 3]))
 
 (expect 18
-        (code-instruction (deb 0 0 2)))
+        (encode-instruction (deb 0 0 2)))
 
 (expect (end)
         (decode-instruction 0))
 
 (expect (deb 0 0 2)
         (decode-instruction 18))
+
+(expect (deb 0 0 2)
+        (decode-instruction (encode-instruction (deb 0 0 2))))
 
 (expect 3
         (factors-of-2 8))
@@ -40,18 +42,38 @@
         (decode-pair 27))
 
 (expect 28
-        (code-pair (decode-pair (code-pair [2 3]))))
+        (encode-pair (decode-pair (encode-pair [2 3]))))
+
+(expect 71680
+        (encode-pair (decode-pair (encode-pair [11 17]))))
+
+(expect [2 1 3]
+        (decode-list (encode-list (decode-list 276))))
 
 (expect [2 3]
         (uncode-pair* 27))
 
+(expect [2 3]
+        (uncode-pair* (encode-pair* [2 3])))
+
+(expect 27
+        (encode-pair* (uncode-pair* (encode-pair* [2 3]))))
+
 (expect 786432
-        (code-program [(deb 0 0 2)
+        (encode-program [(deb 0 0 2)
                        (end)]))
 
 (expect [(deb 0 0 2)
          (end)]
         (decode-program 786432))
+
+(expect [(deb 0 0 2)
+         (end)]
+        (decode-program (encode-program (decode-program 786432))))
+
+(expect  786432
+        (encode-program (decode-program (encode-program [(deb 0 0 2)
+                                                         (end)]))))
 
 (expect {1 4
          2 0
@@ -74,14 +96,14 @@
                                       }})))
 
 (expect {1 0
-         2 (code-list [4 5 6])
+         2 (encode-list [4 5 6])
          9 0}
 
         (:registers (run {:program [(push 1 2 1)
                                     (end)]
                           :position 0
                           :registers {1 4
-                                      2 (code-list [5 6])
+                                      2 (encode-list [5 6])
                                       9 0}})))
 
 (expect {1 11
@@ -91,7 +113,7 @@
         (:registers (run {:program   [(pop 1 2 1 1)
                                       (end)]
                           :position  0
-                          :registers {1 (code-pair [3 11])
+                          :registers {1 (encode-pair [3 11])
                                       2 0
                                       9 0}})))
 
@@ -109,13 +131,13 @@
 
 (expect 1
         (eval-urm uurm
-                  [(code-program [(inc 0 1)
+                  [(encode-program [(inc 0 1)
                                   (end)])
-                   (code-list [0])
+                   (encode-list [0])
                    ]))
 
 (expect 2
         (eval-urm uurm
-                  [(code-program add)
-                   (code-list [0 1 1])
+                  [(encode-program add)
+                   (encode-list [0 1 1])
                    ]))


### PR DESCRIPTION
Encoding & decoding of pairs is not currently round-trip. (decode (code x,y)) works but
(encode (decode encoded-pair)) does not. Therefore, code-pair and code-pair* should take 
a pair as opposed to 2 arguments to allow composition.

Also renaming of all 'code' prefixed functions to be prefixed with 'encode' to better
describe their inverse relationship with their associated 'decode' function.